### PR TITLE
Fix of full screen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ export default class TradingViewWidget extends PureComponent {
 
   initWidget = () => {
     /* global TradingView */
-    if (typeof TradingView === 'undefined') return;
+    if (typeof TradingView === 'undefined' || !document.getElementById(this.containerId)) return;
 
     const { widgetType, ...widgetConfig } = this.props;
     const config = { ...widgetConfig, container_id: this.containerId };


### PR DESCRIPTION
When the container is unmounted before the chart is rendered: prevent an unwished full-screen chart
Fixes issue #24