### PR TITLE
Missing prop for 4h chart (240 minutes)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export default class TradingViewWidget extends PureComponent {
       60,
       120,
       180,
+      240,
       '1',
       '3',
       '5',
@@ -62,6 +63,7 @@ export default class TradingViewWidget extends PureComponent {
       '60',
       '120',
       '180',
+      '240',
       IntervalTypes.D,
       IntervalTypes.W
     ]),


### PR DESCRIPTION
According to advanced chart widget example 240 (4h) is a valid interval input: https://www.tradingview.com/widget/advanced-chart/