### PR TITLE
Adding interval prop for monthly charts (M)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ export const BarStyles = {
 
 export const IntervalTypes = {
   D: 'D',
-  W: 'W'
+  W: 'W',
+  M: 'M'
 };
 
 export const RangeTypes = {
@@ -63,7 +64,8 @@ export default class TradingViewWidget extends PureComponent {
       '120',
       '180',
       IntervalTypes.D,
-      IntervalTypes.W
+      IntervalTypes.W,
+      IntervalTypes.M
     ]),
     locale: PropTypes.string,
     news: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
Although it's not mentioned on widget page, chart supports monthly interval. I've tested and using `M` as interval works as expected, it loads monthly chart.