### PR TITLE
Fix: widget not loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ export default class TradingViewWidget extends PureComponent {
     withdateranges: false
   };
 
-  containerId = `${CONTAINER_ID}-${Math.random()}`;
+  containerId = `${CONTAINER_ID}-${Math.random().toString().slice(2)}`;
 
   componentDidMount = () => this.appendScript(this.initWidget);
 


### PR DESCRIPTION
```
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#tradingview-widget-0.08302378337582628' is not a valid selector.
    at Object.embedStylesForFullHeight (https://s3.tradingview.com/tv.js:1:1684)
    at Object.calculateWidgetHeight (https://s3.tradingview.com/tv.js:1:2265)
    at new widget (https://s3.tradingview.com/tv.js:1:5876)
    at TradingViewWidget._this.initWidget (http://localhost:3000/static/js/bundle.js:33894:13)
```

widget is not loading because of "."(not valid selector).
Math.random().toString().slice(2) to remove "0."